### PR TITLE
Add subdomain for erasmus

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -48,13 +48,14 @@ variable "subdomain" {
     "metabolomics.usegalaxy.eu",
     "humancellatlas.usegalaxy.eu",
     "annotation.usegalaxy.eu",
+    "erasmusmc.usegalaxy.eu",
   ]
 }
 
 resource "aws_route53_record" "subdomains" {
   zone_id = "${var.zone_usegalaxy_eu}"
 
-  count = 21
+  count = 22
   name  = "${element(var.subdomain, count.index)}"
 
   type    = "CNAME"


### PR DESCRIPTION
Their IT department is getting super strict and will not let them have a public Galaxy any more, they wish to publish all of their tools on .eu, so I see no reason not to give them a subdomain?