### PR TITLE
add two different Jenkins workers cluster

### DIFF
--- a/instance_jenkins-worker-gold.tf
+++ b/instance_jenkins-worker-gold.tf
@@ -3,7 +3,7 @@ variable "workers-gold" {
 }
 
 variable "workers-gold-volume-size" {
-  default = 50
+  default = 100
 }
 
 resource "openstack_compute_instance_v2" "jenkins-workers-gold" {

--- a/instance_jenkins-worker-gold.tf
+++ b/instance_jenkins-worker-gold.tf
@@ -1,0 +1,54 @@
+variable "workers-gold" {
+  default = 1
+}
+
+variable "workers-gold-volume-size" {
+  default = 50
+}
+
+resource "openstack_compute_instance_v2" "jenkins-workers-gold" {
+  name            = "worker-${count.index}.gold.build.galaxyproject.eu"
+  image_name      = "${var.jenkins_image}"
+  flavor_name     = "m1.xlarge"
+  key_pair        = "jenkins2"
+  security_groups = ["public"]
+  count           = "${var.workers-gold}"
+
+  network {
+    name = "public"
+  }
+
+  user_data = <<-EOF
+    #cloud-config
+    bootcmd:
+        - test -z "$(blkid /dev/vdb)" && mkfs -t ext4 -L jenkins /dev/vdb
+        - mkdir -p /data
+    mounts:
+        - ["/dev/vdb", "/data", auto, "defaults,nofail", "0", "2"]
+    runcmd:
+        - [ chown, "centos.centos", -R, /data ]
+  EOF
+
+}
+
+resource "openstack_blockstorage_volume_v2" "jenkins-workers-gold-volume" {
+  name        = "jenkins-workers-gold-volume"
+  description = "Data volume for Jenkins worker-${count.index}.gold.build.galaxyproject.eu"
+  size        = "${var.workers-gold-volume-size}"
+  count       = "${var.workers-gold}"
+}
+
+resource "openstack_compute_volume_attach_v2" "jenkins-workers-gold-va" {
+  instance_id = "${element(openstack_compute_instance_v2.jenkins-workers-gold.*.id, count.index)}"
+  volume_id   = "${element(openstack_blockstorage_volume_v2.jenkins-workers-gold-volume.*.id, count.index)}"
+  count       = "${var.workers-gold}"
+}
+
+resource "aws_route53_record" "jenkins-workers-gold" {
+  zone_id = "${var.zone_galaxyproject_eu}"
+  name    = "worker-${count.index}.gold.build.galaxyproject.eu"
+  type    = "A"
+  ttl     = "7200"
+  records = ["${element(openstack_compute_instance_v2.jenkins-workers-gold.*.access_ip_v4, count.index)}"]
+  count   = "${var.workers-gold}"
+}

--- a/instance_jenkins-worker-silver.tf
+++ b/instance_jenkins-worker-silver.tf
@@ -1,0 +1,54 @@
+variable "workers-silver" {
+  default = 1
+}
+
+variable "workers-silver-volume-size" {
+  default = 50
+}
+
+resource "openstack_compute_instance_v2" "jenkins-workers-silver" {
+  name            = "worker-${count.index}.silver.build.galaxyproject.eu"
+  image_name      = "${var.jenkins_image}"
+  flavor_name     = "m1.xlarge"
+  key_pair        = "jenkins2"
+  security_groups = ["public"]
+  count           = "${var.workers-silver}"
+
+  network {
+    name = "public"
+  }
+
+  user_data = <<-EOF
+    #cloud-config
+    bootcmd:
+        - test -z "$(blkid /dev/vdb)" && mkfs -t ext4 -L jenkins /dev/vdb
+        - mkdir -p /data
+    mounts:
+        - ["/dev/vdb", "/data", auto, "defaults,nofail", "0", "2"]
+    runcmd:
+        - [ chown, "centos.centos", -R, /data ]
+  EOF
+
+}
+
+resource "openstack_blockstorage_volume_v2" "jenkins-workers-silver-volume" {
+  name        = "jenkins-workers-silver-volume"
+  description = "Data volume for Jenkins worker-${count.index}.silver.build.galaxyproject.eu"
+  size        = "${var.workers-silver-volume-size}"
+  count       = "${var.workers-silver}"
+}
+
+resource "openstack_compute_volume_attach_v2" "jenkins-workers-silver-va" {
+  instance_id = "${element(openstack_compute_instance_v2.jenkins-workers-silver.*.id, count.index)}"
+  volume_id   = "${element(openstack_blockstorage_volume_v2.jenkins-workers-silver-volume.*.id, count.index)}"
+  count       = "${var.workers-silver}"
+}
+
+resource "aws_route53_record" "jenkins-workers-silver" {
+  zone_id = "${var.zone_galaxyproject_eu}"
+  name    = "worker-${count.index}.silver.build.galaxyproject.eu"
+  type    = "A"
+  ttl     = "7200"
+  records = ["${element(openstack_compute_instance_v2.jenkins-workers-silver.*.access_ip_v4, count.index)}"]
+  count   = "${var.workers-silver}"
+}

--- a/instance_jenkins-worker-silver.tf
+++ b/instance_jenkins-worker-silver.tf
@@ -3,7 +3,7 @@ variable "workers-silver" {
 }
 
 variable "workers-silver-volume-size" {
-  default = 50
+  default = 100
 }
 
 resource "openstack_compute_instance_v2" "jenkins-workers-silver" {


### PR DESCRIPTION
These workers have a volume mounted in the /data path.

I added two different Jenkins workers cluster (gold and silver), each one with one worker.
These workers have a volume mounted in /data path.
In this way, we can operate/modify/update the Jenkins workers one cluster a time avoiding the condition of no workers available.

After the two clusters will be created, I will add the new workers to Jenkins and remove the other two workers that are running now.
