### PR TITLE
Setup training hosted zone for GxIT training

### DIFF
--- a/bin/process-training-output.sh
+++ b/bin/process-training-output.sh
@@ -9,4 +9,4 @@ dns="$(terraform output -json | jq -r '."training_dns'$DOMAIN'".value[]')"
 lines=$(echo "$ips" | wc -l)
 user="$(yes ubuntu | head -n $lines)"
 
-paste <(echo "$user") <(echo "$dns") <(echo "$passwords")
+paste <(echo "$user") <(echo "$ips") <(echo "$dns") <(echo "$passwords")

--- a/gat-ns.tf
+++ b/gat-ns.tf
@@ -6,10 +6,10 @@ resource "aws_route53_zone" "training-gxp-eu" {
   name = "training.galaxyproject.eu"
 }
 
-resource "aws_route53_record" "ns-training-gxp-eu" {
-  zone_id = "${aws_route53_zone.gxp-eu.zone_id}"
-  name    = "training.galaxyproject.eu"
-  type    = "NS"
-  ttl     = "3600"
-  records = "${aws_route53_zone.training-gxp-eu.name_servers}"
-}
+#resource "aws_route53_record" "ns-training-gxp-eu" {
+  #zone_id = "${aws_route53_zone.gxp-eu.zone_id}"
+  #name    = "training.galaxyproject.eu"
+  #type    = "NS"
+  #ttl     = "3600"
+  #records = "${aws_route53_zone.training-gxp-eu.name_servers}"
+#}

--- a/gat-ns.tf
+++ b/gat-ns.tf
@@ -6,10 +6,10 @@ resource "aws_route53_zone" "training-gxp-eu" {
   name = "training.galaxyproject.eu"
 }
 
-#resource "aws_route53_record" "ns-training-gxp-eu" {
-  #zone_id = "${aws_route53_zone.gxp-eu.zone_id}"
-  #name    = "training.galaxyproject.eu"
-  #type    = "NS"
-  #ttl     = "3600"
-  #records = "${aws_route53_zone.training-gxp-eu.name_servers}"
-#}
+resource "aws_route53_record" "ns-training-gxp-eu" {
+  zone_id = "${data.aws_route53_zone.gxp-eu.zone_id}"
+  name    = "training.galaxyproject.eu"
+  type    = "NS"
+  ttl     = "3600"
+  records = "${aws_route53_zone.training-gxp-eu.name_servers}"
+}

--- a/gat-ns.tf
+++ b/gat-ns.tf
@@ -1,5 +1,5 @@
 data "aws_route53_zone" "gxp-eu" {
-  name         = "galaxyproject.eu."
+  zone_id = "${var.zone_galaxyproject_eu}"
 }
 
 resource "aws_route53_zone" "training-gxp-eu" {
@@ -11,5 +11,5 @@ resource "aws_route53_record" "ns-training-gxp-eu" {
   name    = "training.galaxyproject.eu"
   type    = "NS"
   ttl     = "3600"
-  records = "${aws_route53_zone.training-gxp-eu.name_servers}"
+  records = ["${aws_route53_zone.training-gxp-eu.name_servers}"]
 }

--- a/gat-ns.tf
+++ b/gat-ns.tf
@@ -2,14 +2,60 @@ data "aws_route53_zone" "gxp-eu" {
   zone_id = "${var.zone_galaxyproject_eu}"
 }
 
+# Setup the hosted zone below
 resource "aws_route53_zone" "training-gxp-eu" {
   name = "training.galaxyproject.eu"
 }
 
+# It needs its own set of NS
 resource "aws_route53_record" "ns-training-gxp-eu" {
   zone_id = "${data.aws_route53_zone.gxp-eu.zone_id}"
   name    = "training.galaxyproject.eu"
   type    = "NS"
   ttl     = "3600"
   records = ["${aws_route53_zone.training-gxp-eu.name_servers}"]
+}
+
+# Setup an IAM key
+resource "aws_iam_access_key" "training-gxp-eu" {
+  user    = "${aws_iam_user.training-gxp-eu.name}"
+}
+
+# And the user
+resource "aws_iam_user" "training-gxp-eu" {
+  name = "training.galaxyproject.eu"
+  path = "/"
+}
+
+# And setup their policy
+resource "aws_iam_user_policy" "training-subdomain-access" {
+  name = "training-subdomain-access"
+  user = "${aws_iam_user.training-gxp-eu.name}"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:ListHostedZones",
+                "route53:GetChange"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:ChangeResourceRecordSets"
+            ],
+            "Resource": [
+                "arn:aws:route53:::hostedzone/${aws_route53_zone.training-gxp-eu.zone_id}",
+            ]
+        }
+    ]
+}
+EOF
 }

--- a/gat-ns.tf
+++ b/gat-ns.tf
@@ -1,0 +1,15 @@
+data "aws_route53_zone" "gxp-eu" {
+  name         = "galaxyproject.eu."
+}
+
+resource "aws_route53_zone" "training-gxp-eu" {
+  name = "training.galaxyproject.eu"
+}
+
+resource "aws_route53_record" "ns-training-gxp-eu" {
+  zone_id = "${aws_route53_zone.gxp-eu.zone_id}"
+  name    = "training.galaxyproject.eu"
+  type    = "NS"
+  ttl     = "3600"
+  records = "${aws_route53_zone.training-gxp-eu.name_servers}"
+}


### PR DESCRIPTION
We want to run GxIT trainings occasionally. During the GAT in barcelona nate did some magic for the DNS to permit certbot to issue wildcard DNS certs. That magic is not available publicly or to us, and requires someone knowledgeable about dns/bind9

So I'm working an alternate plan:

1. the training.galaxyproject.eu DNS will be moved into a separate "hosted zone".
2. Separate AWS IAM credentials will be generated to access this zone and make changes there.
3. during training we'll be able to generate this credential on demand (with a PR / accessing the value from terraform)
4. and after training we can revoke that credential.

The credential will be scoped to training.gxp.eu, so, it's pretty safe?