### PR TITLE
Update dns.tf (rename ssds1 -> zfs0f)

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -146,16 +146,16 @@ resource "aws_route53_record" "build-usegalaxy" {
   records         = ["132.230.223.230"]
 }
 
-## SSD tank
+## ZFS server #1 (all flash)
 resource "aws_route53_record" "ssds1-galaxyproject" {
   zone_id = var.zone_galaxyproject_eu
-  name    = "ssds1.galaxyproject.eu"
+  name    = "zfs0f.galaxyproject.eu"
   type    = "A"
   ttl     = "7200"
   records = ["10.5.68.239"]
 }
 
-## ZFS tank
+## ZFS server #2 (spinning disks w/ flash cache)
 resource "aws_route53_record" "zfs1-galaxyproject" {
   zone_id = var.zone_galaxyproject_eu
   name    = "zfs1.galaxyproject.eu"
@@ -164,7 +164,7 @@ resource "aws_route53_record" "zfs1-galaxyproject" {
   records = ["10.5.68.238"]
 }
 
-## ZFS flash tank
+## ZFS server #3 (all flash)
 resource "aws_route53_record" "zfs2f-galaxyproject" {
   zone_id = var.zone_galaxyproject_eu
   name    = "zfs2f.galaxyproject.eu"
@@ -174,7 +174,7 @@ resource "aws_route53_record" "zfs2f-galaxyproject" {
   #comment
 }
 
-## ZFS flash tank #2
+## ZFS server #4 (all flash)
 resource "aws_route53_record" "zfs3f-galaxyproject" {
   zone_id = var.zone_galaxyproject_eu
   name    = "zfs3f.galaxyproject.eu"


### PR DESCRIPTION
Bernd suggested to rename the host `ssds1` to `zfs0f`, to bring the naming in line with our other ZFS servers and I think the proposal makes sense. This PR also streamlines the comment lines for the ZFS boxes.

Or should we rather rename `ssds1` to `zfs4f`, to retain the current 1-based indexing, which is a bit more intuitive?