### PR TITLE
Change Pavan's VM falvor - requested more RAM

### DIFF
--- a/instance_core_maintenance.tf
+++ b/instance_core_maintenance.tf
@@ -4,7 +4,6 @@ data "openstack_images_image_v2" "maintenance-image" {
 
 resource "openstack_compute_instance_v2" "maintenance" {
   name            = "maintenance.galaxyproject.eu"
-  image_id        = data.openstack_images_image_v2.maintenance-image.id
   flavor_name     = "m1.xlarge"
   key_pair        = "cloud2"
   tags            = []

--- a/instance_dedicated_pavan.tf
+++ b/instance_dedicated_pavan.tf
@@ -5,7 +5,7 @@ data "openstack_images_image_v2" "pavan-image" {
 resource "openstack_compute_instance_v2" "pavan" {
   name            = "Pavan dedicated VM"
   image_id        = data.openstack_images_image_v2.pavan-image.id
-  flavor_name     = "c1.c36m100"
+  flavor_name     = "c1.c36m225"
   key_pair        = "cloud2"
   security_groups = ["default"]
 


### PR DESCRIPTION
@pavanvidem requested a VM that has double the memory for his large-scale single-cell batch correction project.

This flavor has 225 GB of RAM but 36 cores as the previous flavor.