### PR TITLE
Reverting Pavans VM flavour change PR

### DIFF
--- a/instance_dedicated_pavan.tf
+++ b/instance_dedicated_pavan.tf
@@ -5,7 +5,7 @@ data "openstack_images_image_v2" "pavan-image" {
 resource "openstack_compute_instance_v2" "pavan" {
   name            = "Pavan dedicated VM"
   image_id        = data.openstack_images_image_v2.pavan-image.id
-  flavor_name     = "c1.c36m225"
+  flavor_name     = "c1.c36m100"
   key_pair        = "cloud2"
   security_groups = ["default"]
 


### PR DESCRIPTION
Currently, the Jenkins job is failing as Terraform could not provision this request because we do not have the required resources in our cloud. To fix the Jenkins job this change is being reverted temporarily. Once the required resources are available we can proceed with this change.