### PR TITLE
Change maintenance node's OS and reduce disk size

### DIFF
--- a/instance_core_maintenance.tf
+++ b/instance_core_maintenance.tf
@@ -16,7 +16,7 @@ resource "openstack_compute_instance_v2" "maintenance" {
   block_device {
     uuid                  = data.openstack_images_image_v2.maintenance-image.id
     source_type           = "image"
-    volume_size           = 50
+    volume_size           = 500
     destination_type      = "volume"
     boot_index            = 0
     delete_on_termination = true

--- a/instance_core_maintenance.tf
+++ b/instance_core_maintenance.tf
@@ -1,5 +1,5 @@
 data "openstack_images_image_v2" "maintenance-image" {
-  name = "Rocky 9.0"
+  name = "generic-rockylinux8-v60-j167-5f3adb0e100c-main"
 }
 
 resource "openstack_compute_instance_v2" "maintenance" {
@@ -16,7 +16,7 @@ resource "openstack_compute_instance_v2" "maintenance" {
   block_device {
     uuid                  = data.openstack_images_image_v2.maintenance-image.id
     source_type           = "image"
-    volume_size           = 256
+    volume_size           = 50
     destination_type      = "volume"
     boot_index            = 0
     delete_on_termination = true


### PR DESCRIPTION
Changing image from rocky 9 to generic rocky 8 so we can set up HTCondor and move HTCondor cron tasks from `sn06` to the maintenance node. Also, the maintenance node is not going to need much storage so reducing it from 256 to 50.