### PR TITLE
Change cm DNS records from sn05 to sn06

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -134,7 +134,7 @@ resource "aws_route53_record" "cm-galaxyproject" {
   name            = "condor-cm.galaxyproject.eu"
   type            = "CNAME"
   ttl             = "86400"
-  records         = ["sn05.galaxyproject.eu"]
+  records         = ["sn06.galaxyproject.eu"]
 }
 
 resource "aws_route53_record" "build-usegalaxy" {

--- a/instance_core_maintenance.tf
+++ b/instance_core_maintenance.tf
@@ -7,7 +7,7 @@ resource "openstack_compute_instance_v2" "maintenance" {
   flavor_name     = "m1.xlarge"
   key_pair        = "cloud2"
   tags            = []
-  security_groups = ["default"]
+  security_groups = ["default", "rsyslog"]
 
   network {
     name = "bioinf"


### PR DESCRIPTION
As part of DB server migration HTCondor central manager will be deployed on sn06.

Relevant PR: https://github.com/usegalaxy-eu/infrastructure-playbook/pull/783
DB server migration issue: https://github.com/usegalaxy-eu/issues/issues/436