### PR TITLE
Update image and the flavor of Dilmurat's VM

### DIFF
--- a/instance_dedicated_dilmurat.tf
+++ b/instance_dedicated_dilmurat.tf
@@ -1,11 +1,11 @@
 data "openstack_images_image_v2" "dilmurat-image" {
-  name = "vggp-gpu-v60-j310-1fad751e0150-main"
+  name = "vggp-v60-gpu-j322-692e75a7c101-main"
 }
 
 resource "openstack_compute_instance_v2" "dilmurat" {
   name            = "dilmurat dedicated VM"
   image_id        = data.openstack_images_image_v2.dilmurat-image.id
-  flavor_name     = "g1.c8m20g1"
+  flavor_name     = "g1.c8m20g1d50"
   key_pair        = "cloud2"
   security_groups = ["default", "public-ssh"]
 


### PR DESCRIPTION
The previous image has issues with installing CUDA and NVIDIA drivers due to the broken CUDA repo GPG key. Manual debugging and installation attempts do not fix due to the lack of storage on the root disk so this PR updates the flavor along with the GPU image (using the same image as the one we use for our worker nodes).