### PR TITLE
Update Anup's GPU VM flavor

### DIFF
--- a/instance_dedicated_gpu-alpha.tf
+++ b/instance_dedicated_gpu-alpha.tf
@@ -8,7 +8,7 @@ data "openstack_images_image_v2" "gpu-node-alpha-image" {
 
 resource "openstack_compute_instance_v2" "gpu-node-alpha" {
   name            = var.gpu-node-alpha-dns
-  flavor_name     = "g1.c36m100g1"
+  flavor_name     = "g1.c8m100g1d50"
   key_pair        = "cloud2"
   security_groups = ["default", "public-ssh"]
 


### PR DESCRIPTION
The old flavor is not available anymore and Anup agreed to this new GPU VM flavor (Note: His GPU VM with old flavor does not exist anymore as it was removed as part of the BWCloud GPU infra changes). 

Also, this is going to be a test to see if we can actually launch this new flavor because we are currently unable to launch VGCN worker nodes with flavor `g1.c8m40g1d50`.