### PR TITLE
Add GxIT subdomains

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -236,16 +236,50 @@ resource "aws_route53_record" "ftp" {
 #  records = ["usegalaxy.eu"]
 #}
 #
-#resource "aws_route53_record" "it-subdomain-main" {
-#  zone_id = var.zone_usegalaxy_eu
-#
-#  # Guess new domains won't get this for now, but whatever.
-#  count   = 23
-#  name    = "*.interactivetoolentrypoint.interactivetool.${element(var.subdomain, count.index)}"
-#  type    = "CNAME"
-#  ttl     = "7200"
-#  records = ["usegalaxy.eu"]
-#}
+
+# If your subdomain needs GxIT privileges please place your subdomain at the end of the list and increase the counter `count` in the `it-subdomain-main` resource
+variable "it-subdomain" {
+  type = list(string)
+
+  default = [
+    "annotation.usegalaxy.eu",
+    "aqua.usegalaxy.eu",
+    "beta.usegalaxy.eu",
+    "build.usegalaxy.eu",
+    "cheminformatics.usegalaxy.eu",
+    "climate.usegalaxy.eu",
+    "clipseq.usegalaxy.eu",
+    "ecology.usegalaxy.eu",
+    "erasmusmc.usegalaxy.eu",
+    "graphclust.usegalaxy.eu",
+    "hicexplorer.usegalaxy.eu",
+    "humancellatlas.usegalaxy.eu",
+    "imaging.usegalaxy.eu",
+    "usegalaxy.eu",
+    "test.internal.usegalaxy.eu",
+    "live.usegalaxy.eu",
+    "metabolomics.usegalaxy.eu",
+    "metagenomics.usegalaxy.eu",
+    "nanopore.usegalaxy.eu",
+    "proteomics.usegalaxy.eu",
+    "rna.usegalaxy.eu",
+    "singlecell.usegalaxy.eu",
+    "stats.usegalaxy.eu",
+    "streetscience.usegalaxy.eu",
+    "test.usegalaxy.eu"
+  ]
+}
+
+resource "aws_route53_record" "it-subdomain-main" {
+  # allow_overwrite = true
+  zone_id = var.zone_usegalaxy_eu
+  count   = 25
+  name    = "*.interactivetoolentrypoint.interactivetool.${element(var.it-subdomain, count.index)}"
+  type    = "CNAME"
+  ttl     = "7200"
+  records = ["usegalaxy.eu"]
+}
+
 #
 ## https://727a121642ce1f94-3a20d7fa7b014959af58c7f6a47d1af.interactivetoolentrypoint.interactivetool.test.internal.usegalaxy.eu/
 ##resource "aws_route53_record" "it-subdomain-test" {

--- a/dns.tf
+++ b/dns.tf
@@ -266,14 +266,15 @@ variable "it-subdomain" {
     "singlecell.usegalaxy.eu",
     "stats.usegalaxy.eu",
     "streetscience.usegalaxy.eu",
-    "test.usegalaxy.eu"
+    "test.usegalaxy.eu",
+    "earth-system.usegalaxy.eu"
   ]
 }
 
 resource "aws_route53_record" "it-subdomain-main" {
   # allow_overwrite = true
   zone_id = var.zone_usegalaxy_eu
-  count   = 25
+  count   = 26
   name    = "*.interactivetoolentrypoint.interactivetool.${element(var.it-subdomain, count.index)}"
   type    = "CNAME"
   ttl     = "7200"


### PR DESCRIPTION
This PR matches the current state of IT subdomains in AWS Route 53.

I have cross-checked the current wildcard IT CNAME records list in our AWS Route53 and added a new variable. So, in the future, if a subdomain requests GxIT privileges, we can simply add that subdomain to this variable and increase the counter. This way, we do not allow GxITs for all subdomains by default (hence a new exclusive variable).