### PR TITLE
Beacon importer image

### DIFF
--- a/instance_dedicated_beacon_import.tf
+++ b/instance_dedicated_beacon_import.tf
@@ -1,6 +1,6 @@
 data "openstack_images_image_v2" "beacon-import-image" {
-  # BW Cloud basic Rocky 9 image
-  name = "Rocky 9.0"
+  # VGCN Rocky 9.2 generic image
+  name = "vgcn~rockylinux-9.2-x86_64~+generic+internal~20231221~57137~python-script~9975044"
 }
 
 resource "openstack_compute_instance_v2" "beacon-import" {

--- a/instance_dedicated_beacon_import.tf
+++ b/instance_dedicated_beacon_import.tf
@@ -1,6 +1,6 @@
 data "openstack_images_image_v2" "beacon-import-image" {
   # VGCN Rocky 9.2 generic image
-  name = "vgcn~rockylinux-9.2-x86_64~+generic+internal~20231221~57137~python-script~9975044"
+  name = "vgcn~rockylinux-9.2-x86_64~+generic+internal~20240102~70050~dev~6f78a5f~mira_local_build"
 }
 
 resource "openstack_compute_instance_v2" "beacon-import" {


### PR DESCRIPTION
Using the
`vgcn~rockylinux-9.2-x86_64~+generic+internal~20240102~70050~dev~6f78a5f~mira_local_build`
I built with the build.py script. I tested the image briefly by launching and ssh into the vm.