### PR TITLE
Make terraform work again

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -274,7 +274,7 @@ variable "it-subdomain" {
 resource "aws_route53_record" "it-subdomain-main" {
   allow_overwrite = true
   zone_id         = var.zone_usegalaxy_eu
-  count           = 26
+  count           = 25
   name            = "*.interactivetoolentrypoint.interactivetool.${element(var.it-subdomain, count.index)}"
   type            = "CNAME"
   ttl             = "7200"

--- a/dns.tf
+++ b/dns.tf
@@ -257,7 +257,6 @@ variable "it-subdomain" {
     "humancellatlas.usegalaxy.eu",
     "imaging.usegalaxy.eu",
     "usegalaxy.eu",
-    "test.internal.usegalaxy.eu",
     "live.usegalaxy.eu",
     "metabolomics.usegalaxy.eu",
     "metagenomics.usegalaxy.eu",

--- a/instance_dedicated_beacon_import.tf
+++ b/instance_dedicated_beacon_import.tf
@@ -1,6 +1,7 @@
 data "openstack_images_image_v2" "beacon-import-image" {
   # VGCN Rocky 9.2 generic image
-  name = "vgcn~rockylinux-9-latest-x86_64~+generic+internal~20240123~55931~HEAD~5b66040"
+  name        = "vgcn~rockylinux-9-latest-x86_64~+generic+internal~20240123~55931~HEAD~5b66040"
+  most_recent = true
 }
 
 resource "openstack_compute_instance_v2" "beacon-import" {


### PR DESCRIPTION
We need to add `most_recent = true` to avoid terraform breaking when there is more than one image version.
test.internal subdomain caused the following error with AWS:
~~~
RRSet of type CNAME with DNS name \052.interactivetoolentrypoint.interactivetool.test.internal.usegalaxy.eu. is not permitted as it conflicts with other records with the same DNS name in zone usegalaxy.eu
~~~
Afaik we are not using this subdomain, so we can simply remove it