### PR TITLE
create htcondor shared port secgroup and attach it to the maintenance node

### DIFF
--- a/instance_core_maintenance.tf
+++ b/instance_core_maintenance.tf
@@ -7,7 +7,7 @@ resource "openstack_compute_instance_v2" "maintenance" {
   flavor_name     = "m1.xlarge"
   key_pair        = "cloud2"
   tags            = []
-  security_groups = ["default", "rsyslog"]
+  security_groups = ["default", "rsyslog", "htcondor_shared_port"]
 
   network {
     name = "bioinf"

--- a/secgroup_condor-shared-port.tf
+++ b/secgroup_condor-shared-port.tf
@@ -1,0 +1,14 @@
+resource "openstack_networking_secgroup_v2" "htcondor_shared_port" {
+  name                 = "htcondor_shared_port"
+  description          = "[tf] HTCcondor shared port profile"
+  delete_default_rules = "true"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "htcondor_shared_port_ingress_ipv4" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = "9628"
+  port_range_max    = "9628"
+  security_group_id = openstack_networking_secgroup_v2.htcondor_shared_port.id
+}


### PR DESCRIPTION
This is needed as the `condor_q -global` will not fetch the queued jobs from the maintenance node due to blocked access to the scheduler. 

This PR will create the required security group and add an ingress rule (opens port 9628, which is configured at the moment as the [htcondor_port](https://github.com/usegalaxy-eu/infrastructure-playbook/blob/8697f28fe8064a92f3303f882ebb2f6854eccaf9/group_vars/htcondor-secondary/vars.yml#L8), [see issue](https://github.com/usegalaxy-eu/issues/issues/348)) and then attach the group to the maintenance node.