### PR TITLE
Scale up stats flavor small → large

### DIFF
--- a/instance_core_stats.tf
+++ b/instance_core_stats.tf
@@ -1,7 +1,7 @@
 resource "openstack_compute_instance_v2" "grafana" {
   name            = "stats.galaxyproject.eu"
   image_name      = "stats_15_04_2024"
-  flavor_name     = "m1.small"
+  flavor_name     = "m1.large"
   key_pair        = "cloud2"
   security_groups = ["default", "public-web2"]
 


### PR DESCRIPTION
When I started the oncall backend, the machine almost fully stuck,
I should have checked the flavor first. 1 core and 2G can't be enough for 3 docker images and a grafana server