### PR TITLE
Add mailforward site verification record

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -305,10 +305,21 @@ resource "aws_route53_record" "usegalaxy_eu_dmarc_txt" {
   ]
 }
 
-resource "aws_route53_record" "usegalaxy_eu_spf_txt" {
+resource "aws_route53_record" "usegalaxy_eu_forwardmail_validation_txt" {
   allow_overwrite = true
   zone_id         = var.zone_usegalaxy_eu
   name            = ""
+  type            = "TXT"
+  ttl             = "3600"
+  records = [
+    "forward-email-site-verification=XS8hOkR5lO"
+  ]
+}
+
+resource "aws_route53_record" "usegalaxy_eu_spf_txt" {
+  allow_overwrite = true
+  zone_id         = var.zone_usegalaxy_eu
+  name            = "@"
   type            = "TXT"
   ttl             = "3600"
   records = [


### PR DESCRIPTION
The verification record was deployed manually because I assumed it was only needed once, but I was wrong.
To make SPF still work the record needs to be renamed to "@" which has the same effect but lets you create two root TXT records.
Closes issue https://github.com/usegalaxy-eu/issues/issues/596