### PR TITLE
Spin up new upload VM in new cloud

### DIFF
--- a/instance_core_upload.tf
+++ b/instance_core_upload.tf
@@ -1,35 +1,34 @@
-# 26.04.2024: Disabled as the instance might be moved to a KVM host and this is currently still running in the old cloud
-# variable "upload-dns" {
-#   default = "upload.galaxyproject.eu"
-# }
+variable "upload-dns" {
+  default = "upload.galaxyproject.eu"
+}
 
-# data "openstack_images_image_v2" "upload-image" {
-#   name = "generic-internal-v60-j333-fb0029b7a329-dev"
-# }
+data "openstack_images_image_v2" "upload-image" {
+  name = "generic-internal-v60-j333-fb0029b7a329-dev"
+}
 
-# resource "openstack_compute_instance_v2" "upload" {
-#   name            = var.upload-dns
-#   image_id        = data.openstack_images_image_v2.upload-image.id
-#   flavor_name     = "m1.medium"
-#   key_pair        = "cloud2"
-#   security_groups = ["default", "public-ssh", "public-web2", "ufr-ingress"]
+resource "openstack_compute_instance_v2" "upload" {
+  name            = var.upload-dns
+  image_id        = data.openstack_images_image_v2.upload-image.id
+  flavor_name     = "m1.medium"
+  key_pair        = "cloud2"
+  security_groups = ["default", "public-ssh", "public-web2", "ufr-ingress"]
 
-#   network {
-#     name = "bioinf"
-#   }
+  network {
+    name = "bioinf"
+  }
 
-#   user_data = <<-EOF
-#     #cloud-config
-#     package_update: true
-#     package_upgrade: true
-#   EOF
-# }
+  user_data = <<-EOF
+    #cloud-config
+    package_update: true
+    package_upgrade: true
+  EOF
+}
 
-# resource "aws_route53_record" "upload-galaxyproject" {
-#   allow_overwrite = true
-#   zone_id         = var.zone_galaxyproject_eu
-#   name            = var.upload-dns
-#   type            = "A"
-#   ttl             = "600"
-#   records         = ["${openstack_compute_instance_v2.upload.access_ip_v4}"]
-# }
+resource "aws_route53_record" "upload-galaxyproject" {
+  allow_overwrite = true
+  zone_id         = var.zone_galaxyproject_eu
+  name            = var.upload-dns
+  type            = "A"
+  ttl             = "600"
+  records         = ["${openstack_compute_instance_v2.upload.access_ip_v4}"]
+}

--- a/instance_core_upload.tf
+++ b/instance_core_upload.tf
@@ -3,7 +3,7 @@ variable "upload-dns" {
 }
 
 data "openstack_images_image_v2" "upload-image" {
-  name = "generic-internal-v60-j333-fb0029b7a329-dev"
+  name = "vgcn~rockylinux-9-latest-x86_64~+generic+internal~20240820~42312~HEAD~479ec25"
 }
 
 resource "openstack_compute_instance_v2" "upload" {

--- a/output.tf
+++ b/output.tf
@@ -1,8 +1,7 @@
-# 26.04.2024: upload reosurce is disabled, so we need to comment out the output as well
-# # upload
-# output "upload-node_name" {
-#   value = openstack_compute_instance_v2.upload.name
-# }
-# output "upload-node_public-ip-v4" {
-#   value = openstack_compute_instance_v2.upload.network.0.fixed_ip_v4
-# }
+# upload
+output "upload-node_name" {
+  value = openstack_compute_instance_v2.upload.name
+}
+output "upload-node_public-ip-v4" {
+  value = openstack_compute_instance_v2.upload.network.0.fixed_ip_v4
+}


### PR DESCRIPTION
Old upload VM is errored after the power outage, this creates a new one and updates the record in route53. Everything else should be done by Jenkins automatically

CHANGES:
un-commenting
+ updating the image to latest vgcn-generic-internal