### PR TITLE
Add mq record for traefik and mq02

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -24,6 +24,22 @@ resource "aws_route53_record" "galaxyproject-eu" {
   records         = ["${var.sn06}"]
 }
 
+resource "aws_route53_record" "mq-instance" {
+  zone_id = var.zone_galaxyproject_eu
+  name    = "mq.galaxyproject.eu"
+  type    = "A"
+  ttl     = "600"
+  records = ["${var.traefik}"]
+}
+
+resource "aws_route53_record" "mq-instance" {
+  zone_id = var.zone_galaxyproject_eu
+  name    = "mq02.galaxyproject.eu"
+  type    = "A"
+  ttl     = "600"
+  records = ["10.5.68.232"]
+}
+
 # Subdomains are all just CNAMEs for galaxyproject.eu → proxy-external
 variable "subdomain" {
   type = list(string)

--- a/dns.tf
+++ b/dns.tf
@@ -24,7 +24,7 @@ resource "aws_route53_record" "galaxyproject-eu" {
   records         = ["${var.sn06}"]
 }
 
-resource "aws_route53_record" "mq-instance" {
+resource "aws_route53_record" "mq-proxy" {
   zone_id = var.zone_galaxyproject_eu
   name    = "mq.galaxyproject.eu"
   type    = "A"
@@ -32,7 +32,7 @@ resource "aws_route53_record" "mq-instance" {
   records = ["${var.traefik}"]
 }
 
-resource "aws_route53_record" "mq-instance" {
+resource "aws_route53_record" "mq02-server" {
   zone_id = var.zone_galaxyproject_eu
   name    = "mq02.galaxyproject.eu"
   type    = "A"


### PR DESCRIPTION
- `mq.galaxyproject.eu` points to traefik
- `mq02.galaxyproject.eu` points to the new KVM Rabbitmq server

**Already created, this should be added to the statefile**