### PR TITLE
Add DNS A record for osiris-denbi.galaxyproject.eu

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -70,6 +70,17 @@ resource "aws_route53_record" "tpv-broker" {
   records         = ["${var.traefik}"]
 }
 
+# Record for osiris-denbi.galaxyproject.eu
+# redirected to from osiris.denbi.de
+resource "aws_route53_record" "osiris-denbi" {
+  allow_overwrite = true
+  zone_id         = var.zone_galaxyproject_eu
+  name            = "osiris-denbi.galaxyproject.eu"
+  type            = "A"
+  ttl             = "600"
+  records         = ["${var.traefik}"]
+}
+
 # Subdomains are all just CNAMEs for galaxyproject.eu → proxy-external
 variable "subdomain" {
   type = list(string)


### PR DESCRIPTION
Hi everyone,

This is my first change to this repository so apologies in advance if the content isn't quite right. Any input welcome.
Happy to also read up on any suggested documentation that may explain the infra setup here in more detail.

The PR currently only includes a DNS entry that will be used to serve https://osiris-app.de for de.NBI.
Later on I will include a request for a VM.

This entry will allow testing if the DNS CNAME redirect from `osiris.denbi.de` is working as expected.

Tagging also @bgruening that will be assisting with the OSIRIS setup.