### PR TITLE
Point dnbd-primary to new ESXi

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -264,7 +264,7 @@ resource "aws_route53_record" "dnbd3-primary-galaxyproject" {
   name            = "dnbd3-primary.galaxyproject.eu"
   type            = "A"
   ttl             = "7200"
-  records         = ["10.4.68.250"]
+  records         = ["10.8.103.38"]
 }
 
 ## ZFS server #1 (all flash)


### PR DESCRIPTION
This is part of:
- https://github.com/usegalaxy-eu/issues/issues/628

Merge this only when the new ESXi box is ready, otherwise the pxe nodes will not boot anymore