### PR TITLE
Change dnbd3 proxy dns

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -267,10 +267,10 @@ resource "aws_route53_record" "dnbd3-primary-galaxyproject" {
   records         = ["10.8.103.38"]
 }
 
-resource "aws_route53_record" "dnbd3-secondary-galaxyproject" {
+resource "aws_route53_record" "dnbd3-proxy-galaxyproject" {
   allow_overwrite = true
   zone_id         = var.zone_galaxyproject_eu
-  name            = "dnbd3-secondary.galaxyproject.eu"
+  name            = "dnbd3-proxy.galaxyproject.eu"
   type            = "CNAME"
   ttl             = "7200"
   records         = ["sn12.bi.privat"]


### PR DESCRIPTION
This is mainly for continuity's sake, the record is not used in the dnbd3 setup, but the ansible group is named `proxy` and not secondary. The reason it is not used in ansible inventory is here:
https://github.com/usegalaxy-eu/infrastructure-playbook/pull/1573#discussion_r2218582097