### PR TITLE
test the BUILD_USER var

### DIFF
--- a/instance_core_mq.tf
+++ b/instance_core_mq.tf
@@ -17,3 +17,4 @@
 #   ttl     = "600"
 #   records = ["${openstack_compute_instance_v2.mq-instance.access_ip_v4}"]
 # }
+# test


### PR DESCRIPTION
Need to find out how the user is called that automatically starts the build, so we can trigger it manually in jenkins