### PR TITLE
revert influx dns

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -37,6 +37,15 @@ resource "aws_route53_record" "beacon-galaxyproject" {
   records         = ["beacon.bi.privat"]
 }
 
+resource "aws_route53_record" "influxdb-proxy" {
+  allow_overwrite = true
+  zone_id         = var.zone_galaxyproject_eu
+  name            = "influxdb.galaxyproject.eu"
+  type            = "A"
+  ttl             = "600"
+  records         = ["${var.traefik}"]
+}
+
 resource "aws_route53_record" "tpv-broker" {
   allow_overwrite = true
   zone_id         = var.zone_galaxyproject_eu


### PR DESCRIPTION
We should probably keep this one before changing telegraf output metrics configuration file.  