### PR TITLE
Switch FTP from OS to KVM

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -73,6 +73,15 @@ resource "aws_route53_record" "stats" {
   records         = ["${var.traefik}"]
 }
 
+resource "aws_route53_record" "ftp" {
+  allow_overwrite = true
+  zone_id         = var.zone_usegalaxy_eu
+  name            = "ftp.usegalaxy.eu"
+  type            = "A"
+  ttl             = "600"
+  records         = ["${var.traefik}"]
+}
+
 resource "aws_route53_record" "influxdb-proxy" {
   allow_overwrite = true
   zone_id         = var.zone_galaxyproject_eu

--- a/instance_core_incoming.tf
+++ b/instance_core_incoming.tf
@@ -23,12 +23,3 @@ resource "aws_route53_record" "incoming" {
   ttl             = "600"
   records         = ["${openstack_compute_instance_v2.incoming.access_ip_v4}"]
 }
-
-resource "aws_route53_record" "ftp" {
-  allow_overwrite = true
-  zone_id         = var.zone_usegalaxy_eu
-  name            = "ftp.usegalaxy.eu"
-  type            = "A"
-  ttl             = "600"
-  records         = ["${openstack_compute_instance_v2.incoming.access_ip_v4}"]
-}


### PR DESCRIPTION
Point DNS record `ftp.usegalaxy.eu` to Traefik node, which makes the FTP control port accessible as a Traefik entry point and forwards FTP passive ports to the KVM FTP node in the internal network (see https://github.com/usegalaxy-eu/infrastructure-playbook/pull/2281).